### PR TITLE
feat: SEO improvements — JSON-LD structured data and CDN preconnect

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -129,6 +129,21 @@ async function BlogDetailContent({ slug }: { slug: string }) {
           }}
         />
       )}
+      <Script
+        id="blog-breadcrumb-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              { "@type": "ListItem", position: 1, name: "Home", item: SITE_CONFIG.url },
+              { "@type": "ListItem", position: 2, name: "Blog", item: `${SITE_CONFIG.url}/blog` },
+              { "@type": "ListItem", position: 3, name: blog.title, item: `${SITE_CONFIG.url}/blog/${slug}` },
+            ],
+          }),
+        }}
+      />
 
       <div className="relative mx-auto min-h-screen w-full px-4 py-8 sm:px-8 sm:py-12 md:w-[75%]">
         <div className="mb-6 items-start sm:mb-8">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <link rel="preconnect" href="https://assets.inkubatorit.id" />
+      </head>
       <body
         suppressHydrationWarning // no way i found this bug while using grammarly
         className={`${montserrat.variable} bg-[#0C0C0C] font-sans antialiased`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,17 @@
+import type { Metadata } from "next";
+import Script from "next/script";
 import HomePageClient from "./home-page-client";
 import { fetchProjects } from "@/lib/api";
+import { SITE_CONFIG } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: `${SITE_CONFIG.name} — ${SITE_CONFIG.tagline}`,
+  description: SITE_CONFIG.description,
+  openGraph: {
+    title: `${SITE_CONFIG.name} — ${SITE_CONFIG.tagline}`,
+    description: SITE_CONFIG.description,
+  },
+};
 
 type ShowcaseItem = {
   id: number | string;
@@ -42,8 +54,24 @@ export default async function HomePage() {
   }));
 
   return (
-    <HomePageClient
-      projectShowcase={showcase.length > 0 ? showcase : [...FALLBACK_SHOWCASE]}
-    />
+    <>
+      <Script
+        id="org-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            name: SITE_CONFIG.name,
+            url: SITE_CONFIG.url,
+            logo: SITE_CONFIG.defaultOgImage,
+            description: SITE_CONFIG.description,
+          }),
+        }}
+      />
+      <HomePageClient
+        projectShowcase={showcase.length > 0 ? showcase : [...FALLBACK_SHOWCASE]}
+      />
+    </>
   );
 }

--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, ExternalLink } from "lucide-react";
 import { fetchProjectById, fetchProjects } from "@/lib/api";
 import ExportedImage from "next-image-export-optimizer";
 import Link from "next/link";
+import Script from "next/script";
 import { notFound } from "next/navigation";
 import ImageCarousel from "./image-carousel";
 import { SITE_CONFIG } from "@/lib/seo";
@@ -72,10 +73,26 @@ export default async function ProjectDetailPage({
   }
 
   return (
-    <div
-      className="min-h-screen leading-7 tracking-[-0.06em] text-white"
-      style={{ fontFamily: "Montserrat, sans-serif" }}
-    >
+    <>
+      <Script
+        id="portfolio-breadcrumb-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              { "@type": "ListItem", position: 1, name: "Home", item: SITE_CONFIG.url },
+              { "@type": "ListItem", position: 2, name: "Portfolio", item: `${SITE_CONFIG.url}/portfolio` },
+              { "@type": "ListItem", position: 3, name: project.title, item: `${SITE_CONFIG.url}/portfolio/${id}` },
+            ],
+          }),
+        }}
+      />
+      <div
+        className="min-h-screen leading-7 tracking-[-0.06em] text-white"
+        style={{ fontFamily: "Montserrat, sans-serif" }}
+      >
       <div className="mx-auto max-w-[1540px] px-4 pb-12 md:px-6 md:pb-24">
         <div className="py-6 md:py-8">
           <Link
@@ -207,5 +224,6 @@ export default async function ProjectDetailPage({
         </div>
       </div>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Add explicit `metadata` export and `Organization` JSON-LD to the home page (`src/app/page.tsx`)
- Add `BreadcrumbList` JSON-LD to blog detail pages (`src/app/blog/[slug]/page.tsx`)
- Add `BreadcrumbList` JSON-LD to portfolio detail pages (`src/app/portfolio/[id]/page.tsx`)
- Add `<link rel="preconnect">` hint for `https://assets.inkubatorit.id` CDN in root layout (`src/app/layout.tsx`)

## Test plan

- [x] Run `bun run build` — should complete without errors
- [x] Inspect `/out/index.html`: verify `<title>Inkubator IT — Digital Product Studio</title>`, `<link rel="preconnect" href="https://assets.inkubatorit.id">`, and `<script type="application/ld+json">` with `"@type": "Organization"`
- [x] Inspect `/out/blog/<slug>/index.html`: verify `<script type="application/ld+json">` with `"@type": "BreadcrumbList"`
- [x] Inspect `/out/portfolio/<id>/index.html`: verify `<script type="application/ld+json">` with `"@type": "BreadcrumbList"`
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results) after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)